### PR TITLE
Fix Excalidraw CORS font loading by self-hosting fonts

### DIFF
--- a/.github/workflows/npm_test.yml
+++ b/.github/workflows/npm_test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dist
 .pnp.*
 
 .DS_Store
+
+# Excalidraw fonts (copied from node_modules by postinstall)
+public/fonts/

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -9,6 +9,12 @@ import { ColorSchemeToggle } from '@/components/ColorSchemeToggle/ColorSchemeTog
 import { FileName } from '../FileName/FileName';
 import '@excalidraw/excalidraw/index.css';
 
+declare global {
+  interface Window {
+    EXCALIDRAW_ASSET_PATH: string;
+  }
+}
+
 if (typeof window !== 'undefined') {
   window.EXCALIDRAW_ASSET_PATH = '/';
 }

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -9,6 +9,10 @@ import { ColorSchemeToggle } from '@/components/ColorSchemeToggle/ColorSchemeTog
 import { FileName } from '../FileName/FileName';
 import '@excalidraw/excalidraw/index.css';
 
+if (typeof window !== 'undefined') {
+  window.EXCALIDRAW_ASSET_PATH = '/';
+}
+
 const Excalidraw = dynamic(async () => (await import('@excalidraw/excalidraw')).Excalidraw, {
   ssr: false,
   loading: () => (

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "core-js-pure",
+      "esbuild",
+      "sharp"
+    ]
+  },
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@next/eslint-plugin-next": "^16.1.1",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,6 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "core-js-pure",
-      "esbuild",
-      "sharp"
-    ]
-  },
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@next/eslint-plugin-next": "^16.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prettier:write": "prettier --write \"**/*.{ts,tsx}\"",
     "test": "npm run prettier:check && npm run lint && npm run typecheck && npm run jest",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "postinstall": "node -e \"require('fs').cpSync('node_modules/@excalidraw/excalidraw/dist/prod/fonts', 'public/fonts', {recursive:true})\""
   },
   "dependencies": {
     "@excalidraw/excalidraw": "^0.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,10 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  onlyBuiltDependencies:
+    - core-js-pure
+    - esbuild
+    - sharp
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,10 +3,6 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-  onlyBuiltDependencies:
-    - core-js-pure
-    - esbuild
-    - sharp
 
 importers:
 


### PR DESCRIPTION
## Summary

- Sets `window.EXCALIDRAW_ASSET_PATH = '/'` so Excalidraw loads fonts from the same origin instead of `esm.sh` CDN
- Adds a `postinstall` script that copies Excalidraw fonts from `node_modules` to `public/fonts/` (runs automatically on `pnpm install`, including Vercel builds)
- Gitignores `public/fonts/` since it is generated

## Test plan

- [ ] Run `pnpm install` and verify `public/fonts/` is populated
- [ ] Run `next dev` and confirm no CORS errors in the browser console
- [ ] Deploy to Vercel and confirm fonts load correctly